### PR TITLE
Add code-connect to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ A curation of plugins, prompts, and resources for the [friendly interactive shel
 - [Async Prompt](https://github.com/acomagu/fish-async-prompt) - Make your prompt asynchronous.
 - [Apple Touchbar](https://github.com/rodrigobdz/fish-apple-touchbar) - Customize your [Touch Bar](https://developer.apple.com/design/human-interface-guidelines/macos/touch-bar/touch-bar-overview) in iTerm2.
 - [Abbreviation Tips](https://github.com/Gazorby/fish-abbreviation-tips) - Remembering abbreviations by displaying tips when you can use them.
-- [code-connect-fish-plugin](https://github.com/chvolkmann/code-connect-fish-plugin) - Open files in VS Code over arbitrary remote terminal connections
+- [code-connect](https://github.com/chvolkmann/code-connect) - Open files in VS Code over arbitrary remote terminal connections
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ A curation of plugins, prompts, and resources for the [friendly interactive shel
 - [Async Prompt](https://github.com/acomagu/fish-async-prompt) - Make your prompt asynchronous.
 - [Apple Touchbar](https://github.com/rodrigobdz/fish-apple-touchbar) - Customize your [Touch Bar](https://developer.apple.com/design/human-interface-guidelines/macos/touch-bar/touch-bar-overview) in iTerm2.
 - [Abbreviation Tips](https://github.com/Gazorby/fish-abbreviation-tips) - Remembering abbreviations by displaying tips when you can use them.
+- [code-connect](https://github.com/chvolkmann/code-connect) - Open files in VS Code over arbitrary remote terminal connections
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ A curation of plugins, prompts, and resources for the [friendly interactive shel
 - [Async Prompt](https://github.com/acomagu/fish-async-prompt) - Make your prompt asynchronous.
 - [Apple Touchbar](https://github.com/rodrigobdz/fish-apple-touchbar) - Customize your [Touch Bar](https://developer.apple.com/design/human-interface-guidelines/macos/touch-bar/touch-bar-overview) in iTerm2.
 - [Abbreviation Tips](https://github.com/Gazorby/fish-abbreviation-tips) - Remembering abbreviations by displaying tips when you can use them.
-- [code-connect](https://github.com/chvolkmann/code-connect) - Open files in VS Code over arbitrary remote terminal connections
+- [code-connect-fish-plugin](https://github.com/chvolkmann/code-connect-fish-plugin) - Open files in VS Code over arbitrary remote terminal connections
 
 ## Docker
 


### PR DESCRIPTION
I've created a tool called [code-connect](https://github.com/chvolkmann/code-connect) to run `code` commands from arbitrary remote shells. It's installable through fisher.

This PR adds it to the list.


_please squash_