### PR TITLE
Adds base16-fish-shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ A curation of plugins, prompts, and resources for the [friendly interactive shel
 - [Async Prompt](https://github.com/acomagu/fish-async-prompt) - Make your prompt asynchronous.
 - [Apple Touchbar](https://github.com/rodrigobdz/fish-apple-touchbar) - Customize your [Touch Bar](https://developer.apple.com/design/human-interface-guidelines/macos/touch-bar/touch-bar-overview) in iTerm2.
 - [Abbreviation Tips](https://github.com/Gazorby/fish-abbreviation-tips) - Remembering abbreviations by displaying tips when you can use them.
-- [Base16 Fish Shell](https://github.com/FabioAntunes/base16-fish-shell) - A pure fish shell solution to change your shell's default ANSI colours.
+- [Base16 Fish](https://github.com/FabioAntunes/base16-fish-shell) - A pure Fish solution to change your shell's default ANSI colors.
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ A curation of plugins, prompts, and resources for the [friendly interactive shel
 - [Async Prompt](https://github.com/acomagu/fish-async-prompt) - Make your prompt asynchronous.
 - [Apple Touchbar](https://github.com/rodrigobdz/fish-apple-touchbar) - Customize your [Touch Bar](https://developer.apple.com/design/human-interface-guidelines/macos/touch-bar/touch-bar-overview) in iTerm2.
 - [Abbreviation Tips](https://github.com/Gazorby/fish-abbreviation-tips) - Remembering abbreviations by displaying tips when you can use them.
+- [Base16 Fish Shell](https://github.com/FabioAntunes/base16-fish-shell) - A pure fish shell solution to change your shell's default ANSI colours.
 
 ## Docker
 


### PR DESCRIPTION
A pure fish shell solution to change your shell's default ANSI colours but most importantly, colours 17 to 21 of your shell's 256 colorspace (if supported by your terminal). This script makes it possible to honour the original bright colours of your shell (e.g. bright green is still green and so on) while providing additional base16 colours to applications such as Vim.

Heavily inspired on [Base16 Shell](https://github.com/chriskempson/base16-shell)