### PR TITLE
Add zoxide under Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A curation of plugins, prompts, and resources for the [friendly interactive shel
 
 ## Plugins
 
+- [zoxide](https://github.com/ajeetdsouza/zoxide) - A smarter cd command for your terminal.
 - [z](https://github.com/jethrokuan/z) - Pure-Fish [`rupa/z`](https://github.com/rupa/z)-like directory jumping.
 - [fzf](https://github.com/PatrickF1/fzf.fish) - Ef-🐟-ient key bindings for [`junegunn/fzf`](https://github.com/junegunn/fzf). ([Alternative](https://github.com/jethrokuan/fzf)).
 - [nvm](https://github.com/jorgebucaran/nvm.fish) - Node.js version manager lovingly made for Fish.


### PR DESCRIPTION
Hi, it would be nice if you could include `zoxide` under Fish plugins. It works similar to `z` or `autojump`, but is much faster and comes with a host of improvements to the querying algorithm, ease of configuration, etc.