### PR TITLE
Add osflavor plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ A curation of plugins, prompts, and resources for the [friendly interactive shel
 - [Async Prompt](https://github.com/acomagu/fish-async-prompt) - Make your prompt asynchronous.
 - [Apple Touchbar](https://github.com/rodrigobdz/fish-apple-touchbar) - Customize your [Touch Bar](https://developer.apple.com/design/human-interface-guidelines/macos/touch-bar/touch-bar-overview) in iTerm2.
 - [Abbreviation Tips](https://github.com/Gazorby/fish-abbreviation-tips) - Remembering abbreviations by displaying tips when you can use them.
+- [osflavor](https://github.com/eholic/osflavor) - OS-flavored symbols for your prompt.
 
 ## Docker
 


### PR DESCRIPTION
Add [osflavor](https://github.com/eholic/osflavor) plugin automatically adding OS-flavored symbols to prompt.