### PR TITLE
Update link to Sponge due to the governance change

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A curation of plugins, prompts, and resources for the [friendly interactive shel
 - [Fisher](https://github.com/jorgebucaran/fisher) - Manage functions, completions, bindings, and snippets from the CLI.
 - [Fundle](https://github.com/danhper/fundle) - `config.fish`-based plugin manager.
 - [GitNow](https://github.com/joseluisq/gitnow) - A collection of utility functions to speed up your git workflow.
-- [Sponge](https://github.com/andreiborisov/sponge) - Clean command history from typos automatically.
+- [Sponge](https://github.com/meaningful-ooo/sponge) - Clean command history from typos automatically.
 - [Autopair](https://github.com/jorgebucaran/autopair.fish) - Auto-complete matching pairs in the Fish command-line. ([Alternative](https://github.com/laughedelic/pisces)).
 - [Getopts](https://github.com/jorgebucaran/getopts.fish) - CLI options parser (alternative to the [`argparse`](https://fishshell.com/docs/current/cmds/argparse.html) builtin).
 - [Fishtape](https://github.com/jorgebucaran/fishtape) - TAP-based test runner for Fish.


### PR DESCRIPTION
👋🏻 Hi, just updating the link to Sponge, since I moved it under the governance of [Meaningful](https://meaningful.ooo) — my new startup.