### PR TITLE
docs(docker): replace andreiborisov with purefish

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,5 +46,5 @@ A curation of plugins, prompts, and resources for the [friendly interactive shel
 
 ## Docker
 
-- [Alpine Image](https://hub.docker.com/r/andreiborisov/fish)
+- [Alpine Image](https://hub.docker.com/r/purefish/docker-fish)
 - [Ubuntu LTS Image](https://hub.docker.com/r/dideler/fish-shell)


### PR DESCRIPTION
As @andreiborisov repository has been archived, I have forked is repo, for the legacy :heart:. I rebooted the way to build images leveraging `docker` `buildx`, so we have only one dockerfile and we just change the base image:
```
❯ docker buildx build \
              --build-context alpine=docker-image://alpine:3.17 \
              --file ./Dockerfile \
              --tag=fish-3.5.1 \
              ./
```
https://github.com/pure-fish/docker-fish/blob/main/justfile#L4-L11