### PR TITLE
Add projectdo

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Welcome to the ultimate treasure trove of handpicked plugins, prompts, and other
 - [Getopts](https://github.com/jorgebucaran/getopts.fish) - CLI options parser (alternative to the [`argparse`](https://fishshell.com/docs/current/cmds/argparse.html) builtin)
 - [Fishtape](https://github.com/jorgebucaran/fishtape) - TAP-based test runner for Fish
 - [Pufferfish](https://github.com/nickeb96/puffer-fish) - Text Expansions for Fish
+- [Projectdo](https://github.com/paldepind/projectdo) - Context-aware single-letter abbreviations to build, run, and test any project
 - [Virtualfish](https://github.com/adambrenecki/virtualfish) - Virtualenv wrapper
 - [Async Prompt](https://github.com/acomagu/fish-async-prompt) - Make your prompt asynchronous
 - [Apple Touchbar](https://github.com/rodrigobdz/fish-apple-touchbar) - Customize your [Touch Bar](https://developer.apple.com/design/human-interface-guidelines/macos/touch-bar/touch-bar-overview) in iTerm2


### PR DESCRIPTION
This pull request adds [Projectdo](https://github.com/paldepind/projectdo) to the list.

The idea of Projectdo is to use the improved abbreviations in Fish 3.6 to create show context-dependent abbreviations for testing, running, and building any project. The triggers for the abbreviations are configurable, but for instance, `t` can be used to test any project and then `t` will expand to `cargo test` in a Rust project, `npm test` in a NodeJS project, etc. Similarly, `b` and `r` can be used to build and run any project.

Any feedback is appreciated and thank you in advance for taking the PR into consideration.