### PR TITLE
docs: update link to pure

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Welcome to the ultimate treasure trove of handpicked plugins, prompts, and other
 ## Prompts
 
 - [Tide](https://github.com/IlanCosman/tide) - A modern prompt manager for Fish
-- [Pure](https://github.com/rafaelrinaldi/pure) - [_That_](https://github.com/sindresorhus/pure) ZSH prompt, now in Fish flavor
+- [Pure](https://github.com/pure-fish/pure/) - [_That_](https://github.com/sindresorhus/pure) ZSH prompt, now in Fish flavor
 - [Hydro](https://github.com/jorgebucaran/hydro) - Lag-free prompt with async Git status (ooh la la)
 
 ## Plugins


### PR DESCRIPTION
We migrated to an organisation a [few years back](https://github.com/pure-fish/pure/issues/249#issuecomment-751510259).